### PR TITLE
[Chapter3_공통과제] 1931_회의실배정

### DIFF
--- a/LCSA_study/src/main/kotlin/chapter3/1931_회의실배정.kt
+++ b/LCSA_study/src/main/kotlin/chapter3/1931_회의실배정.kt
@@ -25,7 +25,7 @@ fun main() {
     // 갯수 Count
     var count= 0
 
-    // 정렬된 시간
+    // 정렬된 시간 종료시간이 빠른 시간 기준으로 greedy 적용
     for (mTime in timeTable) {
         if (end <= mTime[0]) {
             end = mTime[1]

--- a/LCSA_study/src/main/kotlin/chapter3/1931_회의실배정.kt
+++ b/LCSA_study/src/main/kotlin/chapter3/1931_회의실배정.kt
@@ -1,0 +1,37 @@
+package chapter3
+
+var timeTable : MutableList<List<Int>> = mutableListOf()
+
+fun input() {
+    val n = readln().toInt()
+
+    // 리스트 입력 ex) [[1,3],[3,5]...]
+    for (i in 1..n) {
+        val mTime = readln().split(" ").map { it.toInt() }
+        timeTable.add(mTime)
+    }
+}
+fun main() {
+
+    // 예제 입력
+    input()
+
+    // 종료시간 기준으로 오름차순 정렬하고 종료시간이 같다면 시작시간 오름차순 정렬
+    val timeTable = timeTable.sortedWith(compareBy({ it[1] }, { it[0] }))
+
+    // 종료시간 초기값
+    var end = -1
+
+    // 갯수 Count
+    var count= 0
+
+    // 정렬된 시간
+    for (mTime in timeTable) {
+        if (end <= mTime[0]) {
+            end = mTime[1]
+            count++
+        }
+    }
+
+    println(count)
+}


### PR DESCRIPTION
## ❓ 문제 번호

- 1931_회의실배정

## ❗풀이 방법 & 고민한 점

- 처음에는 시작시간, 종료시간 - 시작시간 기준으로 정렬해서 풀어보려고 했는데 생각해보니 종료시간 기준으로 풀면 풀리겠다라는 생각이 들었습니다.
- 종료시간이 가장 빠른 순으로 정렬해서 그 친구들을 우선 선택하는 방식으로 풀이했더니 풀이가 가능했습니다.

시간이 소요된 point!
- 코틀린으로 정렬하는 법을 몰라서 시간이 걸렸고 아래와 같은 반례가 있어서 시간이 또 걸렸습니다
- 종료시간이 같다면 시작시간이 빠른 친구들을 고르는 것이 이득인데 이것을 생각 못하였습니다.
-> 정렬 기준 추가!

```kotlin
3
0 0
0 0
0 0
----
3 

이건 아니지..
```

## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴

- 정렬을 하는 건 ide 없이도 쓸 수 있을 정도로 외우고 있으면 좋을 것 같아요!